### PR TITLE
Fix bpf_get/setsockopt failed when TCP over IPv4 via INET6 API

### DIFF
--- a/net/core/filter.c
+++ b/net/core/filter.c
@@ -5399,7 +5399,12 @@ static int sol_ip_sockopt(struct sock *sk, int optname,
 			  char *optval, int *optlen,
 			  bool getopt)
 {
-	if (sk->sk_family != AF_INET)
+
+	/*
+	 * SOL_IP socket options are available on AF_INET and AF_INET6, for
+	 * example, TCP over IPv4 via INET6 API.
+	 */
+	if (!sk_is_inet(sk))
 		return -EINVAL;
 
 	switch (optname) {

--- a/tools/testing/selftests/bpf/progs/setget_sockopt.c
+++ b/tools/testing/selftests/bpf/progs/setget_sockopt.c
@@ -20,6 +20,7 @@ int nr_connect;
 int nr_binddev;
 int nr_socket_post_create;
 int nr_fin_wait1;
+int test_tcp_over_ipv4_via_ipv6;
 
 struct sockopt_test {
 	int opt;
@@ -262,9 +263,15 @@ static int bpf_test_sockopt(void *ctx, struct sock *sk)
 		if (n != ARRAY_SIZE(sol_ip_tests))
 			return -1;
 	} else {
-		n = bpf_loop(ARRAY_SIZE(sol_ipv6_tests), bpf_test_ipv6_sockopt, &lc, 0);
-		if (n != ARRAY_SIZE(sol_ipv6_tests))
-			return -1;
+		if (test_tcp_over_ipv4_via_ipv6) {
+			n = bpf_loop(ARRAY_SIZE(sol_ip_tests), bpf_test_ip_sockopt, &lc, 0);
+			if (n != ARRAY_SIZE(sol_ip_tests))
+				return -1;
+		} else {
+			n = bpf_loop(ARRAY_SIZE(sol_ipv6_tests), bpf_test_ipv6_sockopt, &lc, 0);
+			if (n != ARRAY_SIZE(sol_ipv6_tests))
+				return -1;
+		}
 	}
 
 	return 0;


### PR DESCRIPTION
Pull request for series with
subject: Fix bpf_get/setsockopt failed when TCP over IPv4 via INET6 API
version: 3
url: https://patchwork.kernel.org/project/netdevbpf/list/?series=890376
